### PR TITLE
Post expected SoPN date in slack messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dateutil
 requests
 scraperwiki==0.5.1
 git+https://github.com/polling-bot-4000/polling-bot.git
+sopn-publish-date==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-dateutil
 requests
 scraperwiki==0.5.1
 git+https://github.com/polling-bot-4000/polling-bot.git
-sopn-publish-date==1.2.0
+sopn-publish-date==1.3.0

--- a/scraper.py
+++ b/scraper.py
@@ -80,6 +80,15 @@ def get_title():
 def format_date(d):
     return datetime.datetime.strptime(d, "%Y-%m-%d").strftime("%d/%m/%Y")
 
+def sopn_date_message(sopn_publish_date):
+    if sopn_publish_date is None:
+        return None
+
+    if sopn_publish_date < str(datetime.date.today()):
+        return " (SoPN should be published)"
+    else:
+        return " (SoPN due %s)" % format_date(sopn_publish_date)
+
 def get_slack_message(elections):
     # sort elections by date
     elections = sorted(elections, key=lambda k: k['poll_open_date'])
@@ -87,6 +96,8 @@ def get_slack_message(elections):
     # assemble slack mesages
     slack_messages = [get_emoji() + ' *' + get_title() + '* ' + get_emoji()]
     for election in elections:
+        sopn_message = sopn_date_message(election['sopn_published'])
+
         message = "%s: <%s|%s>. known candidates: %s" % (
             format_date(election['poll_open_date']),
             election['url'],
@@ -96,10 +107,8 @@ def get_slack_message(elections):
             message += " :womble: required"
         if 'locked' in election and election['locked']:
             message += " :lock:"
-        if election['sopn_published'] < str(datetime.date.today()):
-            message += " (SoPN should be published)"
-        else:
-            message += " (SoPN due %s)" % format_date(election['sopn_published'])
+        elif sopn_message is not None:
+            message += sopn_date_message(election['sopn_published'])
 
         slack_messages.append(message)
 

--- a/scraper.py
+++ b/scraper.py
@@ -7,6 +7,10 @@ import time
 from dateutil.relativedelta import relativedelta
 from polling_bot.brain import SlackClient
 from sopn_publish_date import StatementPublishDate, Country
+from sopn_publish_date.election_ids import (
+    InvalidElectionIdError,
+    NoSuchElectionTypeError,
+)
 
 # hack to override sqlite database filename
 # see: https://help.morph.io/t/using-python-3-with-morph-scraperwiki-fork/148
@@ -157,7 +161,7 @@ def get_sopn_date(result):
 
     try:
         return SOPN_PUBLISH_DATE.for_id(election_id, country=country)
-    except BaseException:
+    except (InvalidElectionIdError, NoSuchElectionTypeError):
         return None
 
 

--- a/scraper.py
+++ b/scraper.py
@@ -211,7 +211,7 @@ def get_elections():
                             'url': "https://candidates.democracyclub.org.uk/election/%s/constituencies" % (election_id),
                             'post_id': None,
                             'locked': False,
-                            'sopn_published': str(sopn_date)
+                            'sopn_published': str(sopn_date) if sopn_date is not None else None
                         })
                     else:
                         for post in posts:
@@ -224,7 +224,7 @@ def get_elections():
                                 'url': "https://candidates.democracyclub.org.uk/election/%s/post/%s" % (election_id, post),
                                 'post_id': post,
                                 'locked': posts[post]['locked'],
-                                'sopn_published': str(sopn_date)
+                                'sopn_published': str(sopn_date) if sopn_date is not None else None
                             })
                     time.sleep(2)  # have a little snooze to avoid hammering the api
 


### PR DESCRIPTION
* If the post is locked, don't add the SoPN message - there's no point
* If SoPN date is today or in the past we say "should be published" rather than a historic date
* The data model needs an extra field for sopn_published

This resolves #8 