### PR TITLE
only show by-elections

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -96,6 +96,10 @@ def format_date(d):
     return datetime.datetime.strptime(d, "%Y-%m-%d").strftime("%d/%m/%Y")
 
 
+def is_by_election(election_id):
+    return election_id.split(".")[-2] == "by"
+
+
 def get_sopn_message(ballot):
     if ballot["sopn_published"] is None:
         return None
@@ -176,6 +180,7 @@ def get_ballots():
             election
             for election in ee_data["results"]
             if election["identifier_type"] == "ballot"
+            and is_by_election(election["election_id"])
         ]
         for ee_ballot in ee_ballots:
             election_datetime = datetime.datetime.strptime(


### PR DESCRIPTION
The idea behind this project was mainly to surface by-elections because

* scheduled elections tend to have more publicity around them
* the volume of ballots in a scheduled election is too large - slack notification is not a useful format to consume hundreds (maybe even thousands) of data points

Actually filtering to only by-elections using the previous method was quite hard though because we weren't using ballot ids - we were just using election group IDs (which could contain a mix of by-elections and scheduled ones) so basically we just looked at everything and turned Orinoco off when scheduled elections were happening then turned it off again afterwards. Now (since merging #11 ) that we are using ballot IDs, we can actually filter to just by-elections. This means one less thing to remember.